### PR TITLE
dom0: update Dom0 kernel revision to latest Renesas rc16 revision

### DIFF
--- a/layers/meta-xt-dom0-gen5/recipes-kernel/linux/linux-generic-armv8.bbappend
+++ b/layers/meta-xt-dom0-gen5/recipes-kernel/linux/linux-generic-armv8.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-BRANCH = "v6.1.102/rcar-5.2.0.rc11_vpf.rc15"
+BRANCH = "v6.1.102/rcar-5.2.0.rc11_vpf.rc16"
 SRCREV = "ff8c165e0ab6970380f0ca8ac5561bfec1a816d7"
 LINUX_VERSION = "6.1.102"
 


### PR DESCRIPTION
Use latest Renesas Linux release v6.1.102/rcar-5.2.0.rc11_vpf.rc16 as a source for Domain-0 kernel to keep it in sync with other domains.