### PR TITLE
xen: dts: remove smmu_npu1 node to fix SError

### DIFF
--- a/layers/meta-xt-domd-gen5/recipes-kernel/linux/linux-renesas/r8a78000-x5h.dts
+++ b/layers/meta-xt-domd-gen5/recipes-kernel/linux/linux-renesas/r8a78000-x5h.dts
@@ -415,15 +415,6 @@
 		#iommu-cells = <1>;
 		dma-coherent;
 	};
-
-	smmu_npu1: iommu@fc400000 {
-		compatible = "arm,smmu-v3";
-		reg = <0x0 0xfc400000 0x0 0x200000>;
-		interrupts = <0 110 4>;
-		interrupt-names = "combined";
-		#iommu-cells = <1>;
-		dma-coherent;
-	};
 	
 	smmu_hscs_ucie: iommu@fcc00000 {
 		compatible = "arm,smmu-v3";


### PR DESCRIPTION
The actual VDK release doesn't support this device for Windows VDK setup, which leads to SError while SMMU initialization. So, it should be removed for now.