### PR TITLE
Fixed 4.24.0 SDK update

### DIFF
--- a/layers/meta-xt-domd-gen5/recipes-bsp/u-boot/files/0001-gen5-vdk-switch-to-PL011.patch
+++ b/layers/meta-xt-domd-gen5/recipes-bsp/u-boot/files/0001-gen5-vdk-switch-to-PL011.patch
@@ -1,4 +1,4 @@
-From 70e0ac0e48bdd86d97ff48383219a7dc358e5cc4 Mon Sep 17 00:00:00 2001
+From 39d330727cf9503008654d4e94c24bad74a57e2c Mon Sep 17 00:00:00 2001
 From: Dmytro Firsov <dmytro_firsov@epam.com>
 Date: Thu, 8 May 2025 10:38:53 +0300
 Subject: [PATCH 1/3] gen5: vdk: switch to PL011
@@ -60,10 +60,10 @@ index 23143910d99..2a1d142a533 100644
  
  	timer {
 diff --git a/configs/r8a78000_ironhide_defconfig b/configs/r8a78000_ironhide_defconfig
-index f4287ca2f19..b19825a1e3a 100644
+index 05a4a415276..0a8c1d0263b 100644
 --- a/configs/r8a78000_ironhide_defconfig
 +++ b/configs/r8a78000_ironhide_defconfig
-@@ -17,4 +17,5 @@ CONFIG_BOOTCOMMAND="booti 0x61080000 - 0x61000000"
+@@ -17,4 +17,5 @@ CONFIG_BOOTCOMMAND="booti 0x48080000 - 0x48000000"
  CONFIG_BOOTARGS="console=ttyAMA0,38400n8 cma=800M root=/dev/vda"
  CONFIG_ENV_IS_NOWHERE=y
  CONFIG_SYS_CBSIZE=2048

--- a/layers/meta-xt-domd-gen5/recipes-bsp/u-boot/files/0002-gen5-vdk-set-proper-environment-for-xen-booting.patch
+++ b/layers/meta-xt-domd-gen5/recipes-bsp/u-boot/files/0002-gen5-vdk-set-proper-environment-for-xen-booting.patch
@@ -1,4 +1,4 @@
-From 7ad8d8ce574c536fc30c06b802ebe232ece40023 Mon Sep 17 00:00:00 2001
+From d3c0f15b3c5bddd2fcbc2e091f3c3dc361a3eca2 Mon Sep 17 00:00:00 2001
 From: Dmytro Firsov <dmytro_firsov@epam.com>
 Date: Thu, 8 May 2025 10:51:09 +0300
 Subject: [PATCH 2/3] gen5: vdk: set proper environment for xen booting
@@ -26,14 +26,14 @@ index 719391bf732..0d40721f98a 100644
  	};
  
 diff --git a/configs/r8a78000_ironhide_defconfig b/configs/r8a78000_ironhide_defconfig
-index b19825a1e3a..6d29473d501 100644
+index 0a8c1d0263b..6d29473d501 100644
 --- a/configs/r8a78000_ironhide_defconfig
 +++ b/configs/r8a78000_ironhide_defconfig
 @@ -13,8 +13,8 @@ CONFIG_TARGET_IRONHIDE=y
  CONFIG_SYS_CLK_FREQ=16666666
  CONFIG_SYS_BOOT_GET_CMDLINE=y
  CONFIG_SYS_BARGSIZE=2048
--CONFIG_BOOTCOMMAND="booti 0x61080000 - 0x61000000"
+-CONFIG_BOOTCOMMAND="booti 0x48080000 - 0x48000000"
 -CONFIG_BOOTARGS="console=ttyAMA0,38400n8 cma=800M root=/dev/vda"
 +CONFIG_USE_BOOTCOMMAND=y
 +CONFIG_BOOTCOMMAND="bootm 0x48080000 0x84000000 0x48000000"

--- a/layers/meta-xt-domd-gen5/recipes-bsp/u-boot/files/0003-gen5-vdk-disable-CONFIG_ARCH_FIXUP_FDT_MEMORY.patch
+++ b/layers/meta-xt-domd-gen5/recipes-bsp/u-boot/files/0003-gen5-vdk-disable-CONFIG_ARCH_FIXUP_FDT_MEMORY.patch
@@ -1,4 +1,4 @@
-From 3a954e017d464ce8da0f789a14ab97991e80026a Mon Sep 17 00:00:00 2001
+From 222814fae22371631297932d113e72b5e43487b8 Mon Sep 17 00:00:00 2001
 From: Leonid Komarianskyi <leonid_komarianskyi@epam.com>
 Date: Fri, 9 May 2025 23:50:36 +0300
 Subject: [PATCH 3/3] gen5: vdk: disable CONFIG_ARCH_FIXUP_FDT_MEMORY

--- a/layers/meta-xt-domd-gen5/recipes-bsp/u-boot/u-boot_2025.%.bbappend
+++ b/layers/meta-xt-domd-gen5/recipes-bsp/u-boot/u-boot_2025.%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-BRANCH = "v2025.01/rcar-7.0.0.rc2_vpf.rc4"
-SRCREV = "8d4340bf361b53ce7a0c17d51816bdf177d546f8"
+BRANCH = "v2025.01/rcar-7.0.0.rc2"
+SRCREV = "ad4e16cb4a9cc88b469bef8ff3e80f9657031786"
 
 SRC_URI:append = "\
     file://0001-gen5-vdk-switch-to-PL011.patch \

--- a/prod-devel-rcar-gen5-vdk.yaml
+++ b/prod-devel-rcar-gen5-vdk.yaml
@@ -39,7 +39,7 @@ common_data:
   domd_domu_sources: &DOMD_DOMU_SOURCES
     - type: git
       url: https://github.com/renesas-rcar/meta-renesas.git
-      rev: 36667d7e52cdfc1b3c0b2924f5ec8454a5a1b50a # scarthgap
+      rev: 8a22a732df4bb092390daeb1c426b0e8f76df6ed # scarthgap
 
   # Common configuration options for all yocto-based domains
   conf: &COMMON_CONF


### PR DESCRIPTION
Due to pushing some fixes to meta-renesas for SDK 4.24.0, we need to update U-Boot and meta-reneas revision to the latest version.