### PR TITLE
Return all CPU to X5H VDK product

### DIFF
--- a/layers/meta-xt-dom0-gen5/recipes-guests/domd/files/domd-x5h.cfg
+++ b/layers/meta-xt-dom0-gen5/recipes-guests/domd/files/domd-x5h.cfg
@@ -298,7 +298,7 @@ iomem = [
 memory = 2048
 
 # Number of VCPUS
-vcpus = 4
+vcpus = 6
 
 # Uncomment this lines and add "/pmu_a76" node to
 # dt_passthrough_nodes to enable PMU feature. 

--- a/layers/meta-xt-dom0-gen5/recipes-guests/domu/files/domu-x5h.cfg
+++ b/layers/meta-xt-dom0-gen5/recipes-guests/domu/files/domu-x5h.cfg
@@ -9,7 +9,7 @@ kernel = "/usr/lib/xen/boot/linux-domu"
 extra = "root=/dev/vda rw rootwait console=hvc0"
 
 # Number of VCPUS
-vcpus = 12
+vcpus = 24
 
 on_crash = 'preserve'
 

--- a/layers/meta-xt-domd-gen5/recipes-kernel/linux/linux-renesas/chosen.dtsi
+++ b/layers/meta-xt-domd-gen5/recipes-kernel/linux/linux-renesas/chosen.dtsi
@@ -1,7 +1,7 @@
 / {
 	chosen {
 		stdout-path = "serial8:38400n8";
-		bootargs = "console=dtuart dtuart=/uart@e5c00000 dom0_mem=512M dom0_max_vcpus=1 xsm=flask flask=permissive bootscrub=0";
+		bootargs = "console=dtuart dtuart=/uart@e5c00000 dom0_mem=512M dom0_max_vcpus=2 xsm=flask flask=permissive bootscrub=0";
 		xen,dom0-bootargs = "root=/dev/ram0 console=hvc0 ignore_loglevel";
 
 		modules {

--- a/layers/meta-xt-domd-gen5/recipes-kernel/linux/linux-renesas/r8a78000-x5h.dts
+++ b/layers/meta-xt-domd-gen5/recipes-kernel/linux/linux-renesas/r8a78000-x5h.dts
@@ -136,6 +136,118 @@
 			enable-method = "spin-table";
 			cpu-release-addr = <0x0 0x7ffff00>;
 		};
+		cpu@40000 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x0 0x40000>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0x0 0x7ffff00>;
+		};
+		cpu@40100 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x0 0x40100>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0x0 0x7ffff00>;
+		};
+		cpu@40200 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x0 0x40200>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0x0 0x7ffff00>;
+		};
+		cpu@40300 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x0 0x40300>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0x0 0x7ffff00>;
+		};
+		cpu@50000 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x0 0x50000>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0x0 0x7ffff00>;
+		};
+		cpu@50100 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x0 0x50100>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0x0 0x7ffff00>;
+		};
+		cpu@50200 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x0 0x50200>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0x0 0x7ffff00>;
+		};
+		cpu@50300 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x0 0x50300>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0x0 0x7ffff00>;
+		};
+		cpu@60000 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x0 0x60000>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0x0 0x7ffff00>;
+		};
+		cpu@60100 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x0 0x60100>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0x0 0x7ffff00>;
+		};
+		cpu@60200 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x0 0x60200>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0x0 0x7ffff00>;
+		};
+		cpu@60300 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x0 0x60300>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0x0 0x7ffff00>;
+		};
+		cpu@70000 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x0 0x70000>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0x0 0x7ffff00>;
+		};
+		cpu@70100 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x0 0x70100>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0x0 0x7ffff00>;
+		};
+		cpu@70200 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x0 0x70200>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0x0 0x7ffff00>;
+		};
+		cpu@70300 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x0 0x70300>;
+			enable-method = "spin-table";
+			cpu-release-addr = <0x0 0x7ffff00>;
+		};
 	};
 
 	memory@48000000 {


### PR DESCRIPTION
Fix for 16 out of 32 core not working was provided, this PR integrates it and returns previous vCPU configuration for all Xen guests.